### PR TITLE
Enable passing arguments on queue creation + introduce buildTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,19 @@ Declare a queue on the server.
   * `binding {object}` optional, configure the queue's bindings
     * `exchange {string}` name of the exchange to bind to
     * `keys {array(string)}` which routing keys to bind
+    * `arguments {object}` optional, arguments table passed to queue.bind
+  * `arguments {object}` optional, arguments table passed to queue.declare
 * `callback(err, queue) {function}` Called when queue declaration is confirmed
   * `err {Error}` non-null when an error occurred
   * `queue {object}` Contains `name` as a `{string}`.
+
+declareQueue calls queue.declare followed by queue.bind if the `binding`
+attribute is set in `options`. queue.bind is called once for each key
+in the `binding.keys` array with the `binding.exchange` and `binding.arguments`
+as arguments.
+
+If `binding` is not present in the options or `binding.keys` is empty
+then queue.bind will not be called.
 
 #### amqp.createPublishChannel(confirm) => AMQPPublishChannel
 
@@ -180,7 +190,7 @@ Declare a queue on the server.
 
 `TODO: write this`
 
-#### channel.publish(exchange, key, body, callback)
+#### channel.publish(exchange, key, body, [fields], callback)
 
 `TODO: write this`
 


### PR DESCRIPTION
queue.bind was not passing options.arguments during queue creation
meaning all queues were created without any arguments.

Introduced buildTable method to allow supporting multiple data types
when creating queues and passing attributes when publishing messages.


Note: I realise this needs tests, it works when I've been running it locally. Would be nice to get feedback before investing that time.

Edit: package.json needs updating too with a version bump